### PR TITLE
snapadc calibration checks in init() method restored

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ future
 katcp
 numpy
 odict
-tornado
+tornado==4.4
 redis
 tftpy
 progressbar2

--- a/src/adc.py
+++ b/src/adc.py
@@ -506,6 +506,8 @@ class HMCAD1511(WishBoneDevice):
         E.g.
             selectInput([1,2,3,4])  (in four channel mode)
             selectInput([1,1,1,1])  (in one channel mode)
+
+            selectInput([1,1,4,4]) (in two channel mode, I assume)
         """
 
         opts = [1, 2, 3, 4]

--- a/src/adc.py
+++ b/src/adc.py
@@ -2,8 +2,7 @@ from .wishbonedevice import WishBoneDevice
 import numpy as np
 import struct,math
 import logging
-
-
+ 
 class HMCAD1511(WishBoneDevice):
 
     # HMCAD1511 does not provide any way of register readback for
@@ -65,8 +64,8 @@ class HMCAD1511(WishBoneDevice):
             'cgain2_ch2' : 0b1111 << 4,
             'cgain1_ch1' : 0b1111 << 8, }
     DICT[0x30] = {  'jitter_ctrl' : 0b11111111 << 0, }
-    DICT[0x31] = {  'channel_num' : 0b111 << 0,
-            'clk_divide' : 0b11 << 8, }
+    DICT[0x31] = {  'channel_num' : 0b111 << 0, # Enable high speed mode -- single, dual, or quad channel
+            'clk_divide' : 0b11 << 8, } # Define clock divider factor 1,2,3,8
     DICT[0x33] = {  'cgain_cfg' : 0b1 << 0,
             'fine_gain_en' : 0b1 << 1, }
     DICT[0x34] = {  'fgain_branch1' : 0b1111111 << 0,
@@ -172,7 +171,6 @@ class HMCAD1511(WishBoneDevice):
             raise ValueError("Invalid parameter")
         self.cs = cs & 0xff
 
-
     # Put some initialization here rather than in __init__ so that instantiate
     # an HMCAD1511 object wouldn't reset/interrupt the running ADCs.
     def init(self,numChannel=4,clkDivide=1,lowClkFreq=False):
@@ -250,9 +248,9 @@ class HMCAD1511(WishBoneDevice):
         """
 
         if mode == 'en_ramp':
-            rid, mask = self._getMask('pat_deskew')
+            rid, mask = self._getMask('pat_deskew') # disable this one
             self.write(self._set(0x0, 0b00, mask), rid)
-            rid, mask = self._getMask(mode)
+            rid, mask = self._getMask(mode) # enable this one
             self.write(self._set(0x0, 0b100, mask), rid)
         elif mode == 'dual_custom_pat':
             if not isinstance(_bits_custom1, int) or not isinstance(_bits_custom2, int):
@@ -629,7 +627,7 @@ class HMCAD1520(HMCAD1511):
         val = self._set(0x0, width, mask)
         rid, mask = self._getMask('low_clk_freq')
         val = self._set(val, lowClkFreq, mask)
-        self.write(val, rid)
+        self.write(val, rid) # value, register-ID
 
         rid, mask = self._getMask('high_speed_mode')
         val = self._set(0x0, numChannel, mask)

--- a/src/snapadc.py
+++ b/src/snapadc.py
@@ -344,6 +344,7 @@ class SnapAdc(object):
         if self.ramp_test(chips_lanes=chips_lanes, nchecks=n_ramp_tests) is True: # Perform ramp pattern checks
             self.logger.info("Ramp test passed.")
         self.setDemux(numChannel=self.numChannel) # Reset demux to operational mode
+        self.adc.test('off') # put it back into normal mode
         self.logger.info('ADC Calibration done.')
         return 
 

--- a/src/snapadc.py
+++ b/src/snapadc.py
@@ -438,7 +438,7 @@ class SnapAdc(object):
             return dict(zip(ram, data))
         elif ram in self.adcList:
             if self.resolution > 8:     # ADC_DATA_WIDTH  == 16
-                fmt = '!1024' + ('h' if signed else 'B')
+                fmt = '!1024' + ('h' if signed else 'H')
                 length = 2048
             else:
                 fmt = '!1024' + ('b' if signed else 'B') 

--- a/src/snapadc.py
+++ b/src/snapadc.py
@@ -88,7 +88,8 @@ class SnapAdc(object):
         try:
             self.resolution  = int(self.device_info['adc_resolution'])
             self.sample_rate = float(self.device_info['sample_rate'])
-            self.num_channel = int(self.device_info['snap_inputs'])
+            self.num_snap_inputs = int(self.device_info['snap_inputs']) # Total number of inputs in a snap board, 3, 6, or 12
+            self.numChannel = self.num_snap_inputs // 3 # Number of input channels per ADC chip, there are three HMCAD15xx chips on each snap board
         except:
             print(self.device_info)
             raise
@@ -164,7 +165,7 @@ class SnapAdc(object):
         self._retry_wait = kwargs.get('retry_wait',1)
 
         if initialize:
-            self.init(sample_rate=self.sample_rate, num_channel=self.num_channel)
+            self.init(sample_rate=self.sample_rate, numChannel=self.numChannel)
 
     def set_gain(self, gain):
         """

--- a/src/snapadc.py
+++ b/src/snapadc.py
@@ -317,7 +317,7 @@ class SnapAdc(object):
         self.selected_taps = {} # keys are chips (0, 1, or 2), values are ints within working_taps dict
         return
 
-    def calibrate_ADCs(self, chips_lanes=None, ker_size=5):
+    def calibrate_ADCs(self, chips_lanes=None, ker_size=5, n_ramp_tests=10):
         """
         Calibrate specified ADCs
 
@@ -337,10 +337,11 @@ class SnapAdc(object):
                 self.logger.info(f'Chip {chip} has working taps: {self.working_taps[chip]}.')
         # Pick taps at random of the ones that passed the test, only for adc_chip_sel
         self.selected_taps = {chip:int(np.random.choice(self.working_taps[chip])) for chip in chips_lanes.keys()}
+        self.logger.info(f'Selected taps are chip:tap = {self.selected_taps}')
         self.logger.info(f'ADC Calibration Stage 2: Align Word/Frame-Clock for chips {list(chips_lanes.keys())}...')
         self.align_frame_clock(chips_lanes=chips_lanes) # Align the Frame/Word-clock 
-        self.logger.info(f'ADC Calibration Stage 3: Ramp testing chips {list(chips_lanes.keys())}...')
-        if self.ramp_test(chips_lanes=chips_lanes) is True: # Perform ramp pattern checks
+        self.logger.info(f'ADC Calibration Stage 3: Ramp testing chips {list(chips_lanes.keys())} (x{n_ramp_tests})...')
+        if self.ramp_test(chips_lanes=chips_lanes, nchecks=n_ramp_tests) is True: # Perform ramp pattern checks
             self.logger.info("Ramp test passed.")
         self.setDemux(numChannel=self.numChannel) # Reset demux to operational mode
         self.logger.info('ADC Calibration done.')

--- a/src/snapadc.py
+++ b/src/snapadc.py
@@ -123,7 +123,7 @@ class SnapAdc(object):
 
         self.clksw = HMC922(host,'adc16_use_synth')
         self.ram = [WishBoneDevice(host,name) for name in self.ramList]
-        ADC='HMCAD1511'
+        #ADC='HMCAD1511'
         if ADC not in ['HMCAD1511','HMCAD1520']:
             raise ValueError("Invalid parameter")
 

--- a/src/snapadc.py
+++ b/src/snapadc.py
@@ -286,12 +286,24 @@ class SnapAdc(object):
         else:
             self.clksw.setSwitch('b')
 
-        # Snipped off ADC calibration here: [Why??]
-        # It's now snap_fengine. [What is snap_fengine?]
-        # Despite above comments someone made about putting these checks
-        # into the mysterious 'snap_fengine', I've put the calibration 
-        # checks back in through ADC_calibration
-        assert self.ADC_calibration(numChannel), "ADC not callibrated"
+        # Calling ADC calibration here can lead to infinit try-catch loop 
+        # (behaviour only observed in 12bit mode)
+        #
+        ## Snipped off ADC calibration here: [Why??]
+        ## It's now snap_fengine. [What is snap_fengine?]
+        ##
+        ## Despite above comments someone made about putting these checks
+        ## into the mysterious 'snap_fengine', I've put the calibration 
+        ## checks back in through ADC_calibration
+        ##
+        ## I re-commented it because of infinite try-catch loop that 
+        ## occurs as init() gets called from _find_working_taps() which
+        ## is called in alignLineClock() which is called in 
+        ## ADC_calibration(); This looping behaviour has only been 
+        ## observed in 12bit mode. I'm now calling ADC_callibration()
+        ## in higher level code, right after snap_adc.init().
+        ## 
+        #assert self.ADC_calibration(numChannel), "ADC not callibrated"
         self._retry_cnt = 0
         self.working_taps = {} # initializing invalidates cached values
         return


### PR DESCRIPTION
- Changed one line in requirements.txt to enforce specific verstion of tornado server to make it compatible with other scripts
- Fixed broken testing routines, they were primarily broken because they were calling methods who's names had been updated
- Added `ADC_callibration()` method to SnapAdc class and called it in `init()`. Without this the ADC's Line and Frame clocks are not aligned.  